### PR TITLE
fix worldgen crash

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/shapes/LithiumEntityCollisions.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/shapes/LithiumEntityCollisions.java
@@ -71,7 +71,7 @@ public class LithiumEntityCollisions {
                         continue;
                     }
 
-                    IChunk chunk = world.getChunk(x >> 4, z >> 4);
+                    IChunk chunk = world.getChunk(x >> 4, z >> 4, world.getChunkStatus(), false);
 
                     if (chunk == null) {
                         continue;


### PR DESCRIPTION
could throw `java.lang.RuntimeException: We are asking a region for a chunk out of
bound ..`